### PR TITLE
Rename `default_greeter` to `greeter` in context tutorial

### DIFF
--- a/docs/tutorial/context/app.py
+++ b/docs/tutorial/context/app.py
@@ -87,8 +87,8 @@ def greet_customer(registry: ServiceRegistry, customer: Customer) -> str:
 
     # Get a Greeter using the customer as context. Use the Customer when
     # generating the greeting.
-    default_greeter: Greeter = container.get(Greeter, context=customer)
-    greeting = default_greeter(customer)
+    greeter: Greeter = container.get(Greeter, context=customer)
+    greeting = greeter(customer)
 
     return greeting
 


### PR DESCRIPTION
`default_greeter` name seems confusing to me because it refers to `Greeter`, but in that line we could get both `Greeter` and `FrenchGreeter` depending on a `context`.