### PR TITLE
Drop py3.4/fix builds with isolated builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
       env: TOXENV=py36
     - python: '3.5'
       env: TOXENV=py35
-    - python: '3.4'
-      env: TOXENV=py34
     - python: 'pypy3'
       env: TOXENV=pypy3
     - python: '3.7'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=41.0.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=find_packages('src', exclude=['tests']),
     package_dir={'': 'src'},
     include_package_data=True,
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     install_requires=requires,
     extras_require={'docs': docs_require, 'testing': tests_require},
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ extras =
     testing
 setenv =
     COVERAGE_FILE=.coverage.{envname}
+requires =
+    pip>=19.2.1
 
 [testenv:coverage]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    py34,py35,py36,py37,pypy3,
+    py35,py36,py37,pypy3,
     coverage,docs
 
 isolated_build = true


### PR DESCRIPTION
I believe that the issue you've been seeing with builds failing is due to the version of setuptools used, by explicitly forcing it to always use the latest version of setuptools, `tox` will have to upgrade the version of `setuptools` installed inside the `.package` virtual environment it creates. I also force an update versions of `pip`, but that may not be necessary in all cases, but it certainly doesn't hurt.