### PR TITLE
pass-props-into-injector

### DIFF
--- a/src/wired/dataclasses/__init__.py
+++ b/src/wired/dataclasses/__init__.py
@@ -1,32 +1,3 @@
-# TODO
-#
-# - TODO ``for_`` allows not inheriting in order to get matches
-#
-# - Unit testing
-#
-# - register_singleton and make the simplest test using it
-#
-# - TODO Injection injection (aka transitive injection)
-#
-# - __call__=True
-#
-# - TODO Argument sniffing on __call__
-#
-# - More tests for context-sensitive, injected, attr, transitive, and others
-#   from the unit tests
-#
-# - Request/View/Context/Datastore pattern
-#
-# - TODO Change factory() to factory
-#
-# - TODO Document @singleton
-#
-# - TODO Handle InitVar
-#
-# - TODO Predicates
-#
-# - TODO Write tests that work with 3.6 and dataclasses backport
-#
 from .decorators import factory, singleton
 from .field_types import injected
 from .models import Context

--- a/src/wired/dataclasses/injector.py
+++ b/src/wired/dataclasses/injector.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, fields, Field, MISSING
-from typing import get_type_hints
+from typing import get_type_hints, Dict, Any
 
 from wired import ServiceContainer
 from wired.dataclasses.models import Context
@@ -17,7 +17,7 @@ class Injector:
     # XXX potentially define a __post_init__ here to process the target
     # to reduce the work done in __call__
 
-    def __call__(self, container):
+    def __call__(self, container, props: Dict[str, Any] = None):
         target = self.target
         context = container.context
 
@@ -31,6 +31,12 @@ class Injector:
 
         # Iterate through the dataclass fields
         for field_name, field_type in get_type_hints(target).items():
+
+            # Highest precedence: this field occurs in the passed-in
+            # props. Check there first.
+            if props and field_name in props:
+                args[field_name] = props[field_name]
+                continue
 
             # Doing this style of bailing out quickly for performance
             # reasons. Don't want to keep doing "if", though it

--- a/tests/dataclasses/unit/test_injector.py
+++ b/tests/dataclasses/unit/test_injector.py
@@ -178,6 +178,20 @@ def test_nothing_needed(container):
     assert Dummy == result.__class__
 
 
+def test_only_props(container):
+    # Our dataclass gets everything passed in as "props", nothing
+    # will come from the registry.
+
+    @dataclass
+    class Dummy:
+        name: str
+
+    inj = Injector(Dummy)
+    props = dict(name='Name Prop')
+    result: Dummy = inj(container, props=props)
+    assert Dummy == result.__class__
+
+
 @dataclass
 class DummySingleton:
     singleton: Singleton
@@ -422,6 +436,16 @@ def test_injected_field_with_attr(monkeypatch, container):
     inj = Injector(DummyIFWA)
     result: DummyIFWA = inj(container)
     assert 'source' == result.target
+
+
+def test_prop_before_injected_field_with_attr(monkeypatch, container):
+    # Using the injected field
+
+    monkeypatch.setattr(container, 'get', DummyIFWA.d_get)
+    inj = Injector(DummyIFWA)
+    props = dict(target='passed in prop')
+    result: DummyIFWA = inj(container, props=props)
+    assert 'passed in prop' == result.target
 
 
 @dataclass


### PR DESCRIPTION
For wired_components, allow passed in "props". If this looks ok, 
and the docs cleanup is merged, I'll then add docs for this.