### PR TITLE
Helpful error message when 'name=' is forgotten

### DIFF
--- a/src/wired/container.py
+++ b/src/wired/container.py
@@ -457,6 +457,10 @@ def _iface_for_type(obj):
     if IInterface.providedBy(obj):
         return obj
 
+    # if the object is a string then the user forgot to specify `name=""`
+    if isinstance(obj, str):
+        raise ValueError("Class expected, not string.  Did you forget 'name=...'?")
+
     # look for a cached iface
     iface = obj.__dict__.get('_service_iface', None)
     if iface is not None:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -241,6 +241,13 @@ def test_unregistered_lookup(registry):
     assert c.get(IBarService, default=marker) is marker
 
 
+def test_missing_factory_name(registry):
+    factory = DummyFactory()
+    registry.register_factory(factory, name='foo')
+    with pytest.raises(ValueError):
+        registry.find_factory('foo')  # forgot the `name` keyword
+
+
 def test_unique_class_objects_with_same_name_dont_conflict(registry):
     def make_class():
         class Greeter:


### PR DESCRIPTION
We've using `pyramid-services` and have had some occasions where developers forgot to specify `name=` when passing a factory name instead of a class/interface.  That resulted in an `AttributeError` about a missing `__dict__` that wasn't very helpful.  To make that problem quicker/easier to diagnose I'm raising `ValueError` with a helpful error message when developer passes a string instead of a class to `find_service()`.